### PR TITLE
Adding MQTT integration - first message only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
+gem 'irb', require: false
+
 group :test do
   gem 'rspec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'irb', require: false
+gem 'mqtt', :git => 'https://github.com/njh/ruby-mqtt.git'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
+    io-console (0.5.6)
+    irb (1.2.3)
+      reline (>= 0.0.1)
+    reline (0.1.3)
+      io-console (~> 0.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -20,6 +25,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  irb
   rspec
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/njh/ruby-mqtt.git
+  revision: d1a9ad7093c7259f8b53c8a7287609c5501a8aa3
+  specs:
+    mqtt (0.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -26,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   irb
+  mqtt!
   rspec
 
 BUNDLED WITH

--- a/devices/smartphone/bike.rb
+++ b/devices/smartphone/bike.rb
@@ -9,6 +9,7 @@ class Bike
 
   def beep
     self.last_beep_at = Time.now
+    p "Bike #{self.plate_no} has beeped"
   end
 
   def self.available

--- a/devices/smartphone/bike.rb
+++ b/devices/smartphone/bike.rb
@@ -1,3 +1,5 @@
+require './devices/smartphone/messages/beep'
+
 class Bike
   attr_accessor :id, :plate_no, :is_available, :last_beep_at
 
@@ -8,8 +10,8 @@ class Bike
   end
 
   def beep
+    BeepMessage.new(self.plate_no).send!
     self.last_beep_at = Time.now
-    p "Bike #{self.plate_no} has beeped"
   end
 
   def self.available

--- a/devices/smartphone/messages/beep.rb
+++ b/devices/smartphone/messages/beep.rb
@@ -1,0 +1,7 @@
+require './mqtt/client/messages/message'
+
+class BeepMessage < Message
+  def topic
+    'bike/beep'
+  end
+end

--- a/devices/smartphone/smartphone.rb
+++ b/devices/smartphone/smartphone.rb
@@ -1,4 +1,6 @@
 require './devices/smartphone/bike'
+require './devices/smartphone/booking'
+require './logging'
 
 class Smartphone
   attr_accessor :user, :email, :booking
@@ -16,16 +18,21 @@ class Smartphone
   end
 
   def login
+    Logging.error "You are already logged in" if logged_in?
+    return if logged_in?
     self.user = self.email
   end
 
   def logout
+    Logging.error "You are already logged out" unless logged_in?
     return unless logged_in?
 
     self.user = nil
+    true
   end
 
   def pick_bike
+    Logging.error "Can't pick a bike unless you are logged in" unless logged_in?
     return unless logged_in?
 
     bikes = Bike.available
@@ -33,13 +40,16 @@ class Smartphone
   end
 
   def book_bike(bike)
-    return unless logged_in?
+    Logging.error "Can't do a booking unless you are logged in" unless logged_in?
+    Logging.error "Can't do a booking when you have a running booking" if has_booking?
+    return if !logged_in? && has_booking?
 
     self.booking = Booking.new user, bike
     self.booking.save!
   end
 
   def cancel_booking
+    Logging.error "Can't cancel: you don't have a running booking" unless has_booking?
     return unless has_booking?
     booking.cancel!
   end

--- a/logging.rb
+++ b/logging.rb
@@ -1,0 +1,11 @@
+class Logging
+  class << self
+    def info msg
+      p "#{Time.now} [INFO] - #{msg}"
+    end
+
+    def error msg
+      p "[ERROR] - #{msg}"
+    end
+  end
+end

--- a/mqtt/Vagrantfile
+++ b/mqtt/Vagrantfile
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "generic/ubuntu1604"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.56.12", bridge: 'virbr4', dev: 'virbr4'
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  #config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "vagrant", "/vagrant", type: "nfs"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+   config.vm.provider "libvirt" do |libvirt|
+    libvirt.qemu_use_session = false
+   end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  config.vm.provision :file do |file|
+    file.source = "./vagrant"
+    file.destination = "$HOME/vagrant"
+  end
+
+  config.vm.provision "shell" do |s|
+    s.path = "./vagrant/provision.sh"
+    s.upload_path = "./vagrant/provision.sh"
+  end
+end

--- a/mqtt/client/messages/message.rb
+++ b/mqtt/client/messages/message.rb
@@ -1,0 +1,19 @@
+require './mqtt/client/mqtt_client'
+
+class Message
+  attr_accessor :topic, :payload, :created_at, :sent_at
+
+  def initialize(payload)
+    self.payload = payload
+    self.created_at = Time.now
+  end
+
+  def topic
+    raise NotImplementedError
+  end
+
+  def send!
+    MQTTClient.client.publish(self.topic, self.payload)
+    self.sent_at = Time.now
+  end
+end

--- a/mqtt/client/mqtt_client.rb
+++ b/mqtt/client/mqtt_client.rb
@@ -1,0 +1,8 @@
+require 'rubygems'
+require 'mqtt'
+
+class MQTTClient
+  def self.client
+    @client ||= MQTT::Client.connect(host: '192.168.56.12', port: 1883)
+  end
+end

--- a/mqtt/vagrant/config/mosquitto.conf
+++ b/mqtt/vagrant/config/mosquitto.conf
@@ -1,0 +1,16 @@
+# Place your local configuration in /etc/mosquitto/conf.d/
+#
+# A full description of the configuration file is at
+# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
+
+pid_file /var/run/mosquitto.pid
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+log_dest file /var/log/mosquitto/mosquitto.log
+
+include_dir /etc/mosquitto/conf.d
+
+listener 1884
+protocol websockets

--- a/mqtt/vagrant/provision.sh
+++ b/mqtt/vagrant/provision.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Installing Mosquitto"
+
+sudo apt-get update
+sudo apt-get install mosquitto mosquitto-clients libmosquitto-dev -y
+
+cd vagrant
+sudo cp ./config/mosquitto.conf /etc/mosquitto/mosquitto.conf
+
+sudo systemctl restart mosquitto
+echo "Installation port: 1884"

--- a/spec/devices/smartphone/bike_spec.rb
+++ b/spec/devices/smartphone/bike_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper.rb'
 require './devices/smartphone/bike'
+require './devices/smartphone/messages/beep'
 
 describe 'Bike' do
   let(:bike) { Bike.new 1, '8287KAJ' }
@@ -20,9 +21,12 @@ describe 'Bike' do
 
   describe '.beep' do
     let(:time) { Time.mktime(2020,04,19) }
+    let(:msg) { double('BeepMessage') }
 
     before do
-      allow(Time).to receive(:now).and_return(time)
+      expect(Time).to receive(:now).and_return(time)
+      expect(BeepMessage).to receive(:new).with(bike.plate_no).and_return(msg).once
+      expect(msg).to receive('send!').once
       bike.beep
     end
 

--- a/spec/mqtt/client/messages/message_spec.rb
+++ b/spec/mqtt/client/messages/message_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require './mqtt/client/messages/message'
+require './mqtt/client/mqtt_client'
+
+describe Message do
+  let(:message) { Message.new 'Hello World!' }
+
+  describe '.new' do
+    subject { message }
+    it 'adds a creation_at timestamp' do
+      expect(message.created_at).not_to be_nil
+    end
+  end
+
+  ['send!', 'topic'].each do |mtd|
+    describe mtd do
+      it { expect { message.send mtd }.to raise_error NotImplementedError }
+    end
+  end
+end
+
+class TestMessage < Message
+  def topic
+    :test
+  end
+end
+
+describe TestMessage do
+  let(:message) { TestMessage.new 'Hello World' }
+
+  describe '.send!' do
+    let(:time) { Time.mktime(2020,04,19) }
+    let(:client) { MQTT::Client.new }
+    let(:payload) { 'Hello World' }
+
+    before do
+      expect(Time).to receive(:now).and_return(time).exactly(4).times
+      expect(MQTTClient).to receive(:client).and_return(client).once
+      expect(client).to receive(:publish).with(:test, payload).once
+
+      message.send!
+    end
+
+    it 'sends a message to MQTT topic' do
+      expect(message.payload).to eq 'Hello World'
+    end
+
+    it 'registers the sent_at time' do
+      expect(message.sent_at).to eq time
+    end
+  end
+end


### PR DESCRIPTION
This PR provides integration with a MQTT server. It adds a message system to ease the manage of all the future messages on the system.

It includes the `ruby-mqtt` gem as a client.

It also provides a development environment to install a mosquitto MQTT server using vagrant.